### PR TITLE
Loookup user by email if username is not found

### DIFF
--- a/flask_appbuilder/security/manager.py
+++ b/flask_appbuilder/security/manager.py
@@ -1006,11 +1006,12 @@ class BaseSecurityManager(AbstractSecurityManager):
             :userinfo: dict with user information the keys have the same name
             as User model columns.
         """
+        user = None
         if "username" in userinfo:
             user = self.find_user(username=userinfo["username"])
-        elif "email" in userinfo:
+        if user is None and "email" in userinfo:
             user = self.find_user(email=userinfo["email"])
-        else:
+        if user is None:
             log.error("User info does not have username or email {0}".format(userinfo))
             return None
         # User is disabled


### PR DESCRIPTION
story/9370
task/10363

Signed-off-by: Kevin Dwyer <kevin.dwyer@unipart.io>

This allows us to create OAuth users in advance, specifying a
placeholder value for the username.


Thank you for contributing to Flask-Appbuilder. 

For Fixes:

Please, prefix the title with "Fix, " and describe in detail what you're fixing and the steps required to reproduce the problem.

For new features:

Please, prefix the title with "New, " and describe this new feature in detail, remember to update documentation.

